### PR TITLE
Fixed implementation contract verification issues and added support for other testnets and mainnets!

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+RINKEBY_RPC_URL=https://alchemy.infura.io/v3/1234567890
+KOVAN_RPC_URL=https://alchemy.infura.io/v3/1234567890
+POLYGON_MUMBAI_RPC_URL=https://rpc-mumbai.maticvigil.com/v1/your-api-key
+POLYGON_MAINNET_RPC_URL=https://rpc-mumbai.maticvigil.com/v1/your-api-key
+MAINNET_RPC_URL=https://rpc-mumbai.maticvigil.com/v1/your-api-key
+PRIVATE_KEY=0xabcdef
+MNEMONIC=thanksPatrick
+ETHERSCAN_API_KEY=YOUR_API_KEY
+POLYGONSCAN_API_KEY=YOUR_API_KEY
+COINMARKETCAP_API_KEY=YOUR_KEY
+REPORT_GAS=true

--- a/deploy/01-deploy-box.js
+++ b/deploy/01-deploy-box.js
@@ -1,6 +1,7 @@
 const { developmentChains, VERIFICATION_BLOCK_CONFIRMATIONS } = require("../helper-hardhat-config")
 
-const { network } = require("hardhat")
+const { network, ethers } = require("hardhat")
+const { verify } = require("../helper-functions")
 
 module.exports = async ({ getNamedAccounts, deployments }) => {
     const { deploy, log } = deployments
@@ -11,10 +12,10 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
         : VERIFICATION_BLOCK_CONFIRMATIONS
 
     log("----------------------------------------------------")
-
+    const arguments = []
     const box = await deploy("Box", {
         from: deployer,
-        args: [],
+        args: arguments,
         log: true,
         waitConfirmations: waitBlockConfirmations,
         proxy: {
@@ -32,7 +33,8 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
     // Verify the deployment
     if (!developmentChains.includes(network.name) && process.env.ETHERSCAN_API_KEY) {
         log("Verifying...")
-        await verify(box.address, [])
+        const boxAddress = (await ethers.getContract("Box_Implementation")).address;
+        await verify(boxAddress, arguments)
     }
     log("----------------------------------------------------")
 }

--- a/deploy/02-deploy-box2.js
+++ b/deploy/02-deploy-box2.js
@@ -1,6 +1,7 @@
 const { developmentChains, VERIFICATION_BLOCK_CONFIRMATIONS } = require("../helper-hardhat-config")
 
 const { network } = require("hardhat")
+const { verify } = require("../helper-functions")
 
 module.exports = async ({ getNamedAccounts, deployments }) => {
     const { deploy, log } = deployments
@@ -11,10 +12,10 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
         : VERIFICATION_BLOCK_CONFIRMATIONS
 
     log("----------------------------------------------------")
-
+    const arguments = []
     const box = await deploy("BoxV2", {
         from: deployer,
-        args: [],
+        args: arguments,
         log: true,
         waitConfirmations: waitBlockConfirmations,
     })

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -11,15 +11,17 @@ require("@openzeppelin/hardhat-upgrades")
  * @type import('hardhat/config').HardhatUserConfig
  */
 
+const RINKEBY_RPC_URL =
+    process.env.RINKEBY_RPC_URL || "https://eth-rinkeby.alchemyapi.io/v2/your-api-key"
+const KOVAN_RPC_URL = process.env.KOVAN_RPC_URL || "https://eth-kovan.alchemyapi.io/v2/your-api-key"
+const POLYGON_MUMBAI_RPC_URL =
+    process.env.POLYGON_MUMBAI_RPC_URL || "https://polygon-mainnet.alchemyapi.io/v2/your-api-key"
+const POLYGON_MAINNET_RPC_URL =
+    process.env.POLYGON_MAINNET_RPC_URL || "https://polygon-mainnet.alchemyapi.io/v2/your-api-key"
 const MAINNET_RPC_URL =
     process.env.MAINNET_RPC_URL ||
     process.env.ALCHEMY_MAINNET_RPC_URL ||
     "https://eth-mainnet.alchemyapi.io/v2/your-api-key"
-const RINKEBY_RPC_URL =
-    process.env.RINKEBY_RPC_URL || "https://eth-rinkeby.alchemyapi.io/v2/your-api-key"
-const KOVAN_RPC_URL = process.env.KOVAN_RPC_URL || "https://eth-kovan.alchemyapi.io/v2/your-api-key"
-const POLYGON_MAINNET_RPC_URL =
-    process.env.POLYGON_MAINNET_RPC_URL || "https://polygon-mainnet.alchemyapi.io/v2/your-api-key"
 const PRIVATE_KEY = process.env.PRIVATE_KEY
 // optional
 const MNEMONIC = process.env.MNEMONIC || "your mnemonic"
@@ -27,6 +29,7 @@ const MNEMONIC = process.env.MNEMONIC || "your mnemonic"
 // Your API key for Etherscan, obtain one at https://etherscan.io/
 const ETHERSCAN_API_KEY = process.env.ETHERSCAN_API_KEY || "Your etherscan API key"
 const POLYGONSCAN_API_KEY = process.env.POLYGONSCAN_API_KEY || "Your polygonscan API key"
+const COINMARKETCAP_API_KEY = process.env.COINMARKETCAP_API_KEY || "Your coinmarket cap API key"
 const REPORT_GAS = process.env.REPORT_GAS || false
 
 module.exports = {
@@ -42,32 +45,23 @@ module.exports = {
         localhost: {
             chainId: 31337,
         },
-        kovan: {
-            url: KOVAN_RPC_URL,
-            accounts: PRIVATE_KEY !== undefined ? [PRIVATE_KEY] : [],
-            //accounts: {
-            //     mnemonic: MNEMONIC,
-            // },
-            saveDeployments: true,
-            chainId: 42,
-        },
         rinkeby: {
             url: RINKEBY_RPC_URL,
             accounts: PRIVATE_KEY !== undefined ? [PRIVATE_KEY] : [],
-            //   accounts: {
-            //     mnemonic: MNEMONIC,
-            //   },
             saveDeployments: true,
             chainId: 4,
         },
-        mainnet: {
-            url: MAINNET_RPC_URL,
+        kovan: {
+            url: KOVAN_RPC_URL,
             accounts: PRIVATE_KEY !== undefined ? [PRIVATE_KEY] : [],
-            //   accounts: {
-            //     mnemonic: MNEMONIC,
-            //   },
             saveDeployments: true,
-            chainId: 1,
+            chainId: 42,
+        },
+        polygonMumbai: {
+            url: POLYGON_MUMBAI_RPC_URL,
+            accounts: PRIVATE_KEY !== undefined ? [PRIVATE_KEY] : [],
+            saveDeployments: true,
+            chainId: 80001,
         },
         polygon: {
             url: POLYGON_MAINNET_RPC_URL,
@@ -75,13 +69,19 @@ module.exports = {
             saveDeployments: true,
             chainId: 137,
         },
+        mainnet: {
+            url: MAINNET_RPC_URL,
+            accounts: PRIVATE_KEY !== undefined ? [PRIVATE_KEY] : [],
+            saveDeployments: true,
+            chainId: 1,
+        },
     },
     etherscan: {
         // npx hardhat verify --network <NETWORK> <CONTRACT_ADDRESS> <CONSTRUCTOR_PARAMETERS>
         apiKey: {
             rinkeby: ETHERSCAN_API_KEY,
             kovan: ETHERSCAN_API_KEY,
-            polygon: POLYGONSCAN_API_KEY,
+            polygonMumbai: POLYGONSCAN_API_KEY,
         },
     },
     gasReporter: {
@@ -89,11 +89,7 @@ module.exports = {
         currency: "USD",
         outputFile: "gas-report.txt",
         noColors: true,
-        // coinmarketcap: process.env.COINMARKETCAP_API_KEY,
-    },
-    contractSizer: {
-        runOnCompile: false,
-        only: ["Raffle"],
+        coinmarketcap: COINMARKETCAP_API_KEY,
     },
     namedAccounts: {
         deployer: {
@@ -110,7 +106,7 @@ module.exports = {
                 version: "0.8.8",
             },
             {
-                version: "0.4.24",
+                version: "0.7.6",
             },
         ],
     },

--- a/helper-hardhat-config.js
+++ b/helper-hardhat-config.js
@@ -1,37 +1,32 @@
 const networkConfig = {
     default: {
         name: "hardhat",
-        keepersUpdateInterval: "30",
     },
     31337: {
         name: "localhost",
-        subscriptionId: "588",
-        gasLane: "0xd89b2bf150e3b9e13446986e571fb9cab24b13cea0a43ea20a6049a85cc807cc", // 30 gwei
-        keepersUpdateInterval: "30",
-        raffleEntranceFee: "100000000000000000", // 0.1 ETH
-        callbackGasLimit: "500000", // 500,000 gas
     },
     4: {
         name: "rinkeby",
-        subscriptionId: "588",
-        gasLane: "0xd89b2bf150e3b9e13446986e571fb9cab24b13cea0a43ea20a6049a85cc807cc", // 30 gwei
-        keepersUpdateInterval: "30",
-        raffleEntranceFee: "100000000000000000", // 0.1 ETH
-        callbackGasLimit: "500000", // 500,000 gas
+    },
+    42: {
+        name: "kovan",
+    },
+    80001: {
+        name: "polygonMumbai",
+    },
+    137: {
+        name: "polygon",
     },
     1: {
         name: "mainnet",
-        keepersUpdateInterval: "30",
     },
 }
 
 const developmentChains = ["hardhat", "localhost"]
 const VERIFICATION_BLOCK_CONFIRMATIONS = 6
-const frontEndContractsFile = "../nextjs-smartcontract-lottery-fcc/constants/contractAddresses.json"
 
 module.exports = {
     networkConfig,
     developmentChains,
     VERIFICATION_BLOCK_CONFIRMATIONS,
-    frontEndContractsFile,
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@nomiclabs/hardhat-etherscan": "^3.0.3",
     "@nomiclabs/hardhat-waffle": "^2.0.3",
-    "@openzeppelin/contracts": "^4.5.0",
+    "@openzeppelin/contracts": "^4.7.3",
     "@openzeppelin/hardhat-upgrades": "^1.15.0",
     "chai": "^4.3.6",
     "dotenv": "^16.0.0",

--- a/scripts/upgrade-box-manual.js
+++ b/scripts/upgrade-box-manual.js
@@ -1,5 +1,6 @@
 const { developmentChains, VERIFICATION_BLOCK_CONFIRMATIONS } = require("../helper-hardhat-config")
 const { network, deployments, deployer } = require("hardhat")
+const { verify } = require("../helper-functions")
 
 async function main() {
     const { deploy, log } = deployments
@@ -11,9 +12,10 @@ async function main() {
 
     log("----------------------------------------------------")
 
+    const arguments = []
     const boxV2 = await deploy("BoxV2", {
         from: deployer,
-        args: [],
+        args: arguments,
         log: true,
         waitConfirmations: waitBlockConfirmations,
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -484,10 +484,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@^4.5.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
-  integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
+"@openzeppelin/contracts@^4.7.3":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.3.tgz#939534757a81f8d69cc854c7692805684ff3111e"
+  integrity sha512-dGRS0agJzu8ybo44pCIf3xBaPQN/65AIXNgK8+4gzKd5kbvlqyxryUYVLJv7fK98Seyd2hDZzVEHSWAh0Bt1Yw==
 
 "@openzeppelin/hardhat-upgrades@^1.15.0":
   version "1.15.0"


### PR DESCRIPTION
Not able to verify `Box.sol` (first implementation contract) on testnets and mainnets.

## Reason
In `01-deploy-box.js` see the following verification code:
```solidity
    // Verify the deployment
    if (!developmentChains.includes(network.name) && process.env.ETHERSCAN_API_KEY) {
        log("Verifying...")
        await verify(box.address, [])
    }
```
Here, `box.address` gives address of proxy contract `OpenZeppelinTransparentProxy` instead of `box.sol`, due to delegate call in proxy contract.

## Possible fix
```solidity
    // Verify the deployment
    if (!developmentChains.includes(network.name) && process.env.ETHERSCAN_API_KEY) {
        log("Verifying...")
        const boxAddress = (await ethers.getContract("Box_Implementation")).address;
        await verify(boxAddress, arguments)
    }
```

