### PR TITLE
Fixed implementation contract verification issues

### DIFF
--- a/deploy/01-deploy-box.js
+++ b/deploy/01-deploy-box.js
@@ -1,6 +1,7 @@
 const { developmentChains, VERIFICATION_BLOCK_CONFIRMATIONS } = require("../helper-hardhat-config")
 
 const { network } = require("hardhat")
+const { verify } = require("../helper-functions")
 
 module.exports = async ({ getNamedAccounts, deployments }) => {
     const { deploy, log } = deployments
@@ -32,7 +33,8 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
     // Verify the deployment
     if (!developmentChains.includes(network.name) && process.env.ETHERSCAN_API_KEY) {
         log("Verifying...")
-        await verify(box.address, [])
+        const boxAddress = (await ethers.getContract("Box_Implementation")).address;
+        await verify(boxAddress, [])
     }
     log("----------------------------------------------------")
 }

--- a/deploy/02-deploy-box2.js
+++ b/deploy/02-deploy-box2.js
@@ -1,6 +1,7 @@
 const { developmentChains, VERIFICATION_BLOCK_CONFIRMATIONS } = require("../helper-hardhat-config")
 
 const { network } = require("hardhat")
+const { verify } = require("../helper-functions")
 
 module.exports = async ({ getNamedAccounts, deployments }) => {
     const { deploy, log } = deployments
@@ -25,7 +26,7 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
     // Verify the deployment
     if (!developmentChains.includes(network.name) && process.env.ETHERSCAN_API_KEY) {
         log("Verifying...")
-        await verify(box.address, arguments)
+        await verify(box.address, [])
     }
     log("----------------------------------------------------")
 }

--- a/scripts/upgrade-box-manual.js
+++ b/scripts/upgrade-box-manual.js
@@ -1,5 +1,6 @@
 const { developmentChains, VERIFICATION_BLOCK_CONFIRMATIONS } = require("../helper-hardhat-config")
 const { network, deployments, deployer } = require("hardhat")
+const { verify } = require("../helper-functions")
 
 async function main() {
     const { deploy, log } = deployments
@@ -21,7 +22,7 @@ async function main() {
     // Verify the deployment
     if (!developmentChains.includes(network.name) && process.env.ETHERSCAN_API_KEY) {
         log("Verifying...")
-        await verify(boxV2.address, arguments)
+        await verify(boxV2.address, [])
     }
 
     // Upgrade!


### PR DESCRIPTION
Not able to verify `Box.sol` (first implementation contract) on testnets and mainnets.

## Reason
In `01-deploy-box.js` see the following verification code:
```solidity
    // Verify the deployment
    if (!developmentChains.includes(network.name) && process.env.ETHERSCAN_API_KEY) {
        log("Verifying...")
        await verify(box.address, [])
    }
```
Here, `box.address` gives address of proxy contract `OpenZeppelinTransparentProxy` instead of `box.sol`, due to delegate call in proxy contract.

## Possible fix
```solidity
    // Verify the deployment
    if (!developmentChains.includes(network.name) && process.env.ETHERSCAN_API_KEY) {
        log("Verifying...")
        const boxAddress = (await ethers.getContract("Box_Implementation")).address;
        await verify(boxAddress, arguments)
    }
```

